### PR TITLE
add chromium as browser

### DIFF
--- a/src/Browser/chromium.coffee
+++ b/src/Browser/chromium.coffee
@@ -1,0 +1,10 @@
+chromium =
+    name: "System Default"
+    executables:
+        "linux[0-9]*":
+            "chromium-browser"
+    args: [
+        "%url%"
+    ]
+
+module.exports = chromium

--- a/src/Browser/chromium.coffee
+++ b/src/Browser/chromium.coffee
@@ -1,5 +1,5 @@
 chromium =
-    name: "System Default"
+    name: "chromium"
     executables:
         "linux[0-9]*":
             "chromium-browser"


### PR DESCRIPTION
Instead of always using the default browser, one may now specify `--browser chromium`.
